### PR TITLE
save/restore card status on suspend/resume

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -14,5 +14,6 @@ package() {
     cd "${pkgname}-${pkgver}"
     install -Dm 755 nvx "${pkgdir}/usr/bin/nvx"
     install -Dm 644 nvx.service "${pkgdir}/usr/lib/systemd/system/nvx.service"
+    install -Dm 644 nvx-suspend-restore "${pkgdir}/usr/lib/systemd/system-sleep""
     install -Dm 644 modprobe.conf "${pkgdir}/usr/lib/modprobe.d/nvx.conf"
 }


### PR DESCRIPTION
fixes #28 but as far as packaging is concerned.

You still need to distribute a new version and then update the version number accordingly.