### PR TITLE
Remove all subdevices

### DIFF
--- a/nvx
+++ b/nvx
@@ -14,7 +14,7 @@ function devices {
             objects |
             select(.id | strings | contains("pci")) |
             select(.children) |
-            .children |= (map(select(.class=="display")) | map(select(.vendor | contains("NVIDIA")))) |
+            .children |= map(select(.vendor | contains("NVIDIA"))) |
             select(.children | length > 0)
         '
 }


### PR DESCRIPTION
Hi there. Apologies for not adhering to any naming guidelines.
My gpu is a 1050-ti (max-q) integrated by HP. It also handles sound over HDMI, using the kernel module `snd_hda_intel`.
Relevant ouput of `lspci -nnk`:
```
...
01:00.0 VGA compatible controller [0300]: NVIDIA Corporation GP107M [GeForce GTX 1050 Ti Mobile] [10de:1c8c] (rev a1)
	DeviceName: NVIDIA GeForce GTX 1050 Ti
	Subsystem: Hewlett-Packard Company GP107M [GeForce GTX 1050 Ti Mobile] [103c:8519]
	Kernel driver in use: nvidia
	Kernel modules: nouveau, nvidia_drm, nvidia
01:00.1 Audio device [0403]: NVIDIA Corporation GP107GL High Definition Audio Controller [10de:0fb9] (rev a1)
	Kernel driver in use: snd_hda_intel
	Kernel modules: snd_hda_intel
...
```
When running `nvx off` the Audio device remains dangling, causing many freezes - the `snd_hda_intel` waits for the device to exit D3_cold and times out after 60000 (!!) ms. Very annoying
```
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 1023ms after resume; waiting
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 2047ms after resume; waiting
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 4095ms after resume; waiting
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 8191ms after resume; waiting
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 16383ms after resume; waiting
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 32767ms after resume; waiting
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: not ready 65535ms after resume; giving up
Jan 05 23:36:33 -- kernel: snd_hda_intel 0000:01:00.1: Unable to change power state from D3cold to D0, device inaccessible
```
The above patch also removes the sound device and fixes these issue. I was only able to test this for my specific device though.
