### PR TITLE
Load modules using the right list, fixes parameter settings

### DIFF
--- a/nvx.py
+++ b/nvx.py
@@ -151,7 +151,7 @@ class Pci:
 
     def load_modules(self):
         log.info("load modules")
-        for module in self.config.unload_kernel_modules_sequence():
+        for module in self.config.load_kernel_modules_sequence():
             log.info(f"load module {module}")
             result = subprocess.run(f"modprobe {module}", shell=True, capture_output=True)
             level = result.returncode == 0 and log.INFO or log.WARNING


### PR DESCRIPTION
Hello xará,
I was having issues with `nvx off` not being able to unload the modules (with `nvidia-drm` complaining about being `in use`). Doing `lsof | grep -i nvidia` gave me that `gnome-shell/mutter` were using the GPU. In the readme, it says I should set `modeset=0` to fix that, but somehow it kept loading it with `modeset=1`. Digging deeper, I noticed that the `load_modules()` function was using the "wrong"/`unload` list of modules (which doesn't have the parameters). This is a 2 character fix, but I can finally do `nvx off` at will.

Thanks for this application.

Best regards,
Pedro Nariyoshi